### PR TITLE
Add dependabot for weekly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "yarn"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "BritishYouthBandAssociation/dev"


### PR DESCRIPTION
This PR proposes adding an automated dependency checker to keep all dependencies up to date. It will run every week and open a PR for any packages needing updates.
